### PR TITLE
Added rif-static-samples/sample-c.tar.bz2 to .gitattributes as an LFS…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@ bluebutton-data-pipeline-sampledata/src/main/resources/pharmacy-names.csv filter
 bluebutton-data-pipeline-sampledata/src/main/resources/prescriber-names.csv filter=lfs diff=lfs merge=lfs -text
 bluebutton-data-pipeline-desynpuf/src/main/resources/de-synpuf/sample-test-c.tar.bz2 filter=lfs diff=lfs merge=lfs -text
 bluebutton-data-pipeline-desynpuf/src/main/resources/de-synpuf/sample-test-d.tar.bz2 filter=lfs diff=lfs merge=lfs -text
+bluebutton-data-pipeline-sampledata/src/main/resources/rif-static-samples/sample-c.tar.bz2 filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Pull request for [CBBD-108: Git LFS not properly tracking the rif-static-samples/sample-c.tar.bz2 file](http://issues.hhsdevcloud.us/browse/CBBD-108)