### PR TITLE
CBBD-125: Tests failing in second FHIR server execution

### DIFF
--- a/bluebutton-data-pipeline-app/pom.xml
+++ b/bluebutton-data-pipeline-app/pom.xml
@@ -135,26 +135,57 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<!-- Launch Jetty instance hosting the Blue Button FHIR server prior 
+				<!-- Launch a Jetty instance hosting the Blue Button FHIR server prior 
 					to running this project's integration tests, and stop it after the integration 
 					tests. Alternatively, for manual testing, manually run 'mvn dependency:copy 
-					org.eclipse.jetty:jetty-maven-plugin:run-war' to start the Jetty server. -->
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-maven-plugin</artifactId>
+					org.codehaus.mojo:exec-maven-plugin:exec@jetty-start' to start the Jetty 
+					server. -->
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>jetty-start</id>
 						<phase>pre-integration-test</phase>
 						<goals>
-							<goal>run-forked</goal>
+							<goal>exec</goal>
 						</goals>
+						<configuration>
+							<executable>${project.build.directory}/../../dev/bluebutton-fhir-server-start.sh</executable>
+							<arguments>
+								<argument>--javahome</argument>
+								<argument>${java.home}</argument>
+								<argument>--maxheaparg</argument>
+								<argument>${its.bbfhir.server.jvmargs}</argument>
+								<argument>--directory</argument>
+								<argument>${project.build.directory}/bbonfhir-server</argument>
+								<argument>--dburl</argument>
+								<argument>${its.bbfhir.db.url}</argument>
+								<argument>--dbusername</argument>
+								<argument>${its.bbfhir.db.username}</argument>
+								<argument>--dbpassword</argument>
+								<argument>${its.bbfhir.db.password}</argument>
+							</arguments>
+
+							<!-- Don't start Jetty if the ITs are being skipped. -->
+							<skip>${skipITs}</skip>
+						</configuration>
 					</execution>
 					<execution>
 						<id>jetty-stop</id>
 						<phase>post-integration-test</phase>
 						<goals>
-							<goal>stop</goal>
+							<goal>exec</goal>
 						</goals>
+						<configuration>
+							<executable>${project.build.directory}/../../dev/bluebutton-fhir-server-stop.sh</executable>
+							<arguments>
+								<argument>--directory</argument>
+								<argument>${project.build.directory}/bbonfhir-server</argument>
+							</arguments>
+
+							<!-- Don't start Jetty if the ITs are being skipped. -->
+							<skip>${skipITs}</skip>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/bluebutton-data-pipeline-app/pom.xml
+++ b/bluebutton-data-pipeline-app/pom.xml
@@ -146,7 +146,7 @@
 						<id>jetty-start</id>
 						<phase>pre-integration-test</phase>
 						<goals>
-							<goal>deploy-war</goal>
+							<goal>run-forked</goal>
 						</goals>
 					</execution>
 					<execution>

--- a/bluebutton-data-pipeline-fhir-load/pom.xml
+++ b/bluebutton-data-pipeline-fhir-load/pom.xml
@@ -144,26 +144,57 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<!-- Launch Jetty instance hosting the Blue Button FHIR server prior 
+				<!-- Launch a Jetty instance hosting the Blue Button FHIR server prior 
 					to running this project's integration tests, and stop it after the integration 
 					tests. Alternatively, for manual testing, manually run 'mvn dependency:copy 
-					org.eclipse.jetty:jetty-maven-plugin:run-war' to start the Jetty server. -->
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-maven-plugin</artifactId>
+					org.codehaus.mojo:exec-maven-plugin:exec@jetty-start' to start the Jetty 
+					server. -->
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
 				<executions>
 					<execution>
 						<id>jetty-start</id>
 						<phase>pre-integration-test</phase>
 						<goals>
-							<goal>run-forked</goal>
+							<goal>exec</goal>
 						</goals>
+						<configuration>
+							<executable>${project.build.directory}/../../dev/bluebutton-fhir-server-start.sh</executable>
+							<arguments>
+								<argument>--javahome</argument>
+								<argument>${java.home}</argument>
+								<argument>--maxheaparg</argument>
+								<argument>${its.bbfhir.server.jvmargs}</argument>
+								<argument>--directory</argument>
+								<argument>${project.build.directory}/bbonfhir-server</argument>
+								<argument>--dburl</argument>
+								<argument>${its.bbfhir.db.url}</argument>
+								<argument>--dbusername</argument>
+								<argument>${its.bbfhir.db.username}</argument>
+								<argument>--dbpassword</argument>
+								<argument>${its.bbfhir.db.password}</argument>
+							</arguments>
+
+							<!-- Don't start Jetty if the ITs are being skipped. -->
+							<skip>${skipITs}</skip>
+						</configuration>
 					</execution>
 					<execution>
 						<id>jetty-stop</id>
 						<phase>post-integration-test</phase>
 						<goals>
-							<goal>stop</goal>
+							<goal>exec</goal>
 						</goals>
+						<configuration>
+							<executable>${project.build.directory}/../../dev/bluebutton-fhir-server-stop.sh</executable>
+							<arguments>
+								<argument>--directory</argument>
+								<argument>${project.build.directory}/bbonfhir-server</argument>
+							</arguments>
+
+							<!-- Don't start Jetty if the ITs are being skipped. -->
+							<skip>${skipITs}</skip>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/bluebutton-data-pipeline-fhir-load/pom.xml
+++ b/bluebutton-data-pipeline-fhir-load/pom.xml
@@ -155,7 +155,7 @@
 						<id>jetty-start</id>
 						<phase>pre-integration-test</phase>
 						<goals>
-							<goal>deploy-war</goal>
+							<goal>run-forked</goal>
 						</goals>
 					</execution>
 					<execution>

--- a/dev/bluebutton-fhir-server-start.sh
+++ b/dev/bluebutton-fhir-server-start.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+# Constants.
+jettyVersion='9.3.11.v20160721'
+jettyArtifact="jetty-distribution-${jettyVersion}.tar.gz"
+jettyInstall="jetty-distribution-${jettyVersion}"
+jettyPortHttps=9094
+jettyPortStop=9095
+jettyTimeoutSeconds=120
+warArtifact='bbonfhir-server-app.war'
+configArtifact='bbonfhir-server-app-jetty-config.xml'
+
+# Calculate the directory that this script is in.
+scriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Use GNU getopt to parse the options passed to this script.
+TEMP=`getopt \
+	-o j:m:d:u:n:p: \
+	--long javahome:,maxheaparg:,directory:,dburl:,dbusername:,dbpassword: \
+	-n 'bluebutton-fhir-server-start.sh' -- "$@"`
+if [ $? != 0 ] ; then echo "Terminating." >&2 ; exit 1 ; fi
+
+# Note the quotes around `$TEMP': they are essential!
+eval set -- "$TEMP"
+
+# Parse the getopt results.
+javaBinDir=""
+maxHeapArg="-Xmx4g"
+directory=
+dbUrl="jdbc:hsqldb:mem:test"
+dbUsername=""
+dbPassword=""
+while true; do
+	case "$1" in
+		-j | --javahome )
+			javaBinDir="${2}/bin/"; shift 2 ;;
+		-m | --maxheaparg )
+			maxHeapArg="$2"; shift 2 ;;
+		-d | --directory )
+			directory="$2"; shift 2 ;;
+		-u | --dburl )
+			dbUrl="$2"; shift 2 ;;
+		-n | --dbusername )
+			dbUsername="$2"; shift 2 ;;
+		-p | --dbpassword )
+			dbPassword="$2"; shift 2 ;;
+		-- ) shift; break ;;
+		* ) break ;;
+	esac
+done
+
+# Verify that all required options were specified.
+if [[ -z "${directory}" ]]; then >&2 echo 'The --directory option is required.'; exit 1; fi
+
+# Verify that java was found.
+command -v "${javaBinDir}java" >/dev/null 2>&1 || { echo >&2 "Java not found. Specify --javahome option."; exit 1; }
+
+# Exit immediately if something fails.
+set -e
+
+# Check for required files.
+for f in "${directory}/${jettyArtifact}" "${directory}/${warArtifact}" "${directory}/${configArtifact}"; do
+	if [[ ! -f "${f}" ]]; then
+		>&2 echo "The following file is required but is missing: '${f}'."
+		exit 1
+	fi
+done
+
+# Unzip Jetty.
+if [[ ! -d "${directory}/${jettyInstall}" ]]; then
+	tar --extract \
+		--file "${directory}/${jettyArtifact}" \
+		--directory "${directory}"
+	echo "Unpacked Jetty dist: '${directory}/${jettyInstall}'"
+
+	# By default, Jetty will enable all sorts of things that we don't need. 
+	# Some of them, e.g. HTTP, are giant security holes. So: disable all 
+	# the things!
+	mv "${directory}/${jettyInstall}/start.ini" "${directory}/${jettyInstall}/start.ini.original"
+fi
+
+# Copy the Jetty resources into its directory (required by Jetty).
+cp "${directory}/${configArtifact}" "${directory}/${jettyInstall}/etc/bbfhir.xml"
+cp "${directory}/bbonfhir-server-app.war" "${directory}/${jettyInstall}"
+
+# Create the Blue Button module for Jetty to load.
+cat <<EOF > "${directory}/${jettyInstall}/modules/bbfhir.mod"
+#
+# A custom Jetty configuration module for the Blue Button API FHIR Server web application.
+#
+
+# As much as possible, use existing modules to pull in the libraries we need.
+# DO NOT, however, pull in any modules that include XML configuration (watch 
+# out for transitive dependencies with this!).
+[depend]
+ext
+
+[lib]
+
+# From modules/server.mod:
+lib/servlet-api-3.1.jar
+lib/jetty-schemas-3.1.jar
+lib/jetty-http-${jettyVersion}.jar
+lib/jetty-server-${jettyVersion}.jar
+lib/jetty-xml-${jettyVersion}.jar
+lib/jetty-util-${jettyVersion}.jar
+lib/jetty-io-${jettyVersion}.jar
+
+# From modules/deploy.mod:
+lib/jetty-deploy-${jettyVersion}.jar
+
+# From modules/webapp.mod:
+lib/jetty-webapp-${jettyVersion}.jar
+
+# From modules/servlet.mod:
+lib/jetty-servlet-${jettyVersion}.jar
+
+# From modules/security.mod:
+lib/jetty-security-${jettyVersion}.jar
+
+# From modules/annotations.mod:
+lib/jetty-annotations-${jettyVersion}.jar
+lib/annotations/*.jar
+
+# From modules/plus.mod:
+lib/jetty-plus-${jettyVersion}.jar
+
+# From modules/jndi.mod:
+lib/jetty-jndi-${jettyVersion}.jar
+lib/jndi/*.jar
+
+[xml]
+etc/bbfhir.xml
+EOF
+
+# Create a new start.ini for Jetty.
+cat <<EOF > "${directory}/${jettyInstall}/start.ini"
+#
+# A trimmed-down start.ini, which only enables this app's actual 
+# dependencies.
+#
+--module=bbfhir
+
+# Set the Jetty configuration properties.
+jetty.ssl.port=${jettyPortHttps}
+jetty.sslContext.keyStorePath=${scriptDirectory}/ssl-stores/server.keystore
+jetty.sslContext.trustStorePath=${scriptDirectory}/ssl-stores/server.truststore
+bbfhir.war.path=bbonfhir-server-app.war
+EOF
+
+# Launch Jetty in the background.
+cd "${directory}/${jettyInstall}"
+jettyLog='logs/jetty-console.log'
+jobs &> /dev/null
+"${javaBinDir}java" \
+	"${maxHeapArg}" \
+	-DSTOP.PORT=${jettyPortStop} \
+	-DSTOP.KEY='supersecure' \
+	-Dbbfhir.db.url="${dbUrl}" \
+	-Dbbfhir.db.username="${dbUsername}" \
+	-Dbbfhir.db.password="${dbPassword}" \
+	-jar start.jar \
+	&> "${jettyLog}" \
+	&
+
+# Calculate Jetty's PID. (Reference: http://unix.stackexchange.com/a/90250)
+newJobStarted="$(jobs -n)"
+if [ -n "${newJobStarted}" ]; then jettyPid=$!; else jettyPid=; fi
+if [[ -z "${jettyPid}" ]]; then
+	>&2 echo 'Server launch failed. Exiting.'
+	exit 2
+fi
+
+# Wait for the "...INFO:oejs.Server:main: Started @..." in the log.
+echo "Server launched with PID '${jettyPid}', logging to '${jettyLog}'. Waiting for it to finish starting..."
+startSeconds=$SECONDS
+endSeconds=$(($startSeconds + $jettyTimeoutSeconds))
+while true; do
+	if grep --quiet "INFO:oejs.Server:main: Started @" "${jettyLog}"; then
+		echo "Server started in $(($SECONDS - $startSeconds)) seconds."
+		break
+	fi
+	if [[ $SECONDS -gt $endSeconds ]]; then
+		>&2 echo "Error: Server failed to start within ${jettyTimeoutSeconds} seconds."
+		kill "${jettyPid}"
+		>&2 echo "Server with PID '${jettyPid}' killed. Exiting."
+		exit 3
+	fi
+	sleep 1
+done
+

--- a/dev/bluebutton-fhir-server-stop.sh
+++ b/dev/bluebutton-fhir-server-stop.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Constants.
+jettyVersion='9.3.11.v20160721'
+jettyInstall="jetty-distribution-${jettyVersion}"
+jettyPortStop=9095
+jettyTimeoutSeconds=120
+
+# Calculate the directory that this script is in.
+scriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Use GNU getopt to parse the options passed to this script.
+TEMP=`getopt \
+	-o j:d: \
+	--long javahome:,directory: \
+	-n 'bluebutton-fhir-server-stop.sh' -- "$@"`
+if [ $? != 0 ] ; then echo "Terminating." >&2 ; exit 1 ; fi
+
+# Note the quotes around `$TEMP': they are essential!
+eval set -- "$TEMP"
+
+# Parse the getopt results.
+javaBinDir=""
+directory=
+while true; do
+	case "$1" in
+		-j | --javahome )
+			javaBinDir="${2}/bin/"; shift 2 ;;
+		-d | --directory )
+			directory="$2"; shift 2 ;;
+		-- ) shift; break ;;
+		* ) break ;;
+	esac
+done
+
+# Verify that all required options were specified.
+if [[ -z "${directory}" ]]; then >&2 echo 'The --directory option is required.'; exit 1; fi
+
+# Verify that java was found.
+command -v "${javaBinDir}java" >/dev/null 2>&1 || { echo >&2 "Java not found. Specify --javahome option."; exit 1; }
+
+# Run the Jetty stop command.
+cd "${directory}/${jettyInstall}"
+jettyLogRun='logs/jetty-console.log'
+jettyLogStop='logs/jetty-stop.log'
+"${javaBinDir}java" \
+	-DSTOP.PORT=${jettyPortStop} \
+	-DSTOP.KEY='supersecure' \
+	-jar start.jar \
+	--stop \
+	&> "${jettyLogStop}"
+
+# Wait for the "...INFO:oejsh.ContextHandler:ShutdownMonitor: Stopped o.e.j.w.WebAppContext@..." in the log.
+echo "Stop request issued. Waiting for server to stop..."
+startSeconds=$SECONDS
+endSeconds=$(($startSeconds + $jettyTimeoutSeconds))
+while true; do
+	if grep --quiet "java.net.ConnectException: Connection refused" "${jettyLogStop}"; then
+		>&2 echo "Server was not running."
+		break
+	fi
+	if grep --quiet "INFO:oejsh.ContextHandler:ShutdownMonitor: Stopped o.e.j.w.WebAppContext@" "${jettyLogRun}"; then
+		echo "Server stopped in $(($SECONDS - $startSeconds)) seconds."
+		break
+	fi
+	if [[ $SECONDS -gt $endSeconds ]]; then
+		>&2 echo "Error: Server failed to stop within ${jettyTimeoutSeconds} seconds."
+		exit 3
+	fi
+	sleep 1
+done
+

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,7 @@
 						<!-- Used by the 'stop' goal. -->
 						<stopPort>9966</stopPort>
 						<stopKey>doesntmatter</stopKey>
+						<stopWait>120</stopWait>
 
 						<!-- Don't run any of this plugin's goals if the ITs are being skipped. -->
 						<skip>${skipITs}</skip>

--- a/pom.xml
+++ b/pom.xml
@@ -215,11 +215,19 @@
 					<configuration>
 						<artifactItems>
 							<artifactItem>
+								<groupId>org.eclipse.jetty</groupId>
+								<artifactId>jetty-distribution</artifactId>
+								<version>9.3.11.v20160721</version>
+								<type>tar.gz</type>
+								<outputDirectory>${project.build.directory}/bbonfhir-server</outputDirectory>
+							</artifactItem>
+							<artifactItem>
 								<groupId>gov.hhs.cms.bluebutton.fhir</groupId>
 								<artifactId>bbonfhir-server-app</artifactId>
 								<version>${bbonfhir-server.version}</version>
 								<type>war</type>
 								<outputDirectory>${project.build.directory}/bbonfhir-server</outputDirectory>
+								<destFileName>bbonfhir-server-app.war</destFileName>
 							</artifactItem>
 							<artifactItem>
 								<groupId>gov.hhs.cms.bluebutton.fhir</groupId>
@@ -228,6 +236,7 @@
 								<type>xml</type>
 								<classifier>jetty-config</classifier>
 								<outputDirectory>${project.build.directory}/bbonfhir-server</outputDirectory>
+								<destFileName>bbonfhir-server-app-jetty-config.xml</destFileName>
 							</artifactItem>
 						</artifactItems>
 						<outputDirectory>${project.build.directory}/wars</outputDirectory>
@@ -236,41 +245,12 @@
 					</configuration>
 				</plugin>
 				<plugin>
-					<!-- Configure the Jetty plugin such that it can be used to launch the 
-						Blue Button FHIR Server, for manual testing or for use in integration tests. -->
-					<groupId>org.eclipse.jetty</groupId>
-					<artifactId>jetty-maven-plugin</artifactId>
-					<version>9.3.11.v20160721</version>
-					<configuration>
-						<!-- The Jetty config file to use. -->
-						<jettyXml>${project.build.directory}/bbonfhir-server/bbonfhir-server-app-${bbonfhir-server.version}-jetty-config.xml</jettyXml>
-						
-						<!-- Ensure that the run-forked goal is non-blocking. -->
-						<waitForChild>false</waitForChild>
-
-						<!-- Configure the JVM to: -->
-						<!-- * Set the JVM's max heap size. -->
-						<!-- * Set the HTTP(S) ports for Jetty to use. If you modify these, 
-							be sure to also update `FhirTestUtilities.FHIR_API`. -->
-						<!-- * Configure Jetty's SSL keystores. These were just manually copied 
-							from `bbonfhir-server.git/dev/ssl-stores/`, for convenience. -->
-						<!-- * Specify the WAR to run. -->
-						<!-- * Configure the DB to be used by the FHIR server. The defaults 
-							(above) are to use a temporary in-mem DB. Can be overridden if needed by 
-							properties specified in devs' settings.xml. -->
-						<!-- Notes on how this property is handled: 1) Don't let auto-formatting 
-							of this POm add extra spaces or line breaks: you'll get weird errors if you 
-							do, 2) don't quote any of the values: you'll get weird errors if you do. -->
-						<jvmArgs>${its.bbfhir.server.jvmargs} -Djetty.ssl.port=9094 -Djetty.sslContext.keyStorePath=${project.build.directory}/../../dev/ssl-stores/server.keystore -Djetty.sslContext.trustStorePath=${project.build.directory}/../../dev/ssl-stores/server.truststore -Dbbfhir.war.path=${project.build.directory}/bbonfhir-server/bbonfhir-server-app-${bbonfhir-server.version}.war -Dbbfhir.db.url=${its.bbfhir.db.url} -Dbbfhir.db.username=${its.bbfhir.db.username} -Dbbfhir.db.password=${its.bbfhir.db.password}</jvmArgs>
-
-						<!-- Used by the 'stop' goal. -->
-						<stopPort>9966</stopPort>
-						<stopKey>doesntmatter</stopKey>
-						<stopWait>120</stopWait>
-
-						<!-- Don't run any of this plugin's goals if the ITs are being skipped. -->
-						<skip>${skipITs}</skip>
-					</configuration>
+					<!-- The exec plugin can be used in child modules to run the 'dev/bluebutton-fhir-server-*.sh' 
+						scripts, which will start and stop the Blue Button API FHIR server for use 
+						in testing. -->
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>exec-maven-plugin</artifactId>
+					<version>1.5.0</version>
 				</plugin>
 				<plugin>
 					<!-- Can be used to run any `*IT.java` integration tests in a project. -->

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 		<capsule.version>1.0.1</capsule.version>
 
 		<!-- The version of the Blue Button FHIR server to test against. -->
-		<bbonfhir-server.version>0.1.0-44</bbonfhir-server.version>
+		<bbonfhir-server.version>0.1.0-45</bbonfhir-server.version>
 
 		<!-- Configure the Blue Button FHIR Server, as it will be run via the Jetty 
 			plugin. These settings are pulled out as POM properties so that they can 

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
 			plugin. These settings are pulled out as POM properties so that they can 
 			be adjusted via profiles. This is required because the CI server doesn't 
 			have enough RAM to run with an in-mem DB, and so requires a different configuration. -->
+		<its.bbfhir.server.jvmargs>-Xmx4g</its.bbfhir.server.jvmargs>
 		<its.bbfhir.db.url>jdbc:hsqldb:mem:test</its.bbfhir.db.url>
 		<its.bbfhir.db.username></its.bbfhir.db.username>
 		<its.bbfhir.db.password></its.bbfhir.db.password>
@@ -241,54 +242,26 @@
 					<artifactId>jetty-maven-plugin</artifactId>
 					<version>9.3.11.v20160721</version>
 					<configuration>
-						<!-- Specify the WAR to run. -->
-						<war>${project.build.directory}/bbonfhir-server/bbonfhir-server-app-${bbonfhir-server.version}.war</war>
-						<webApp>
-							<contextPath>/</contextPath>
-						</webApp>
-
 						<!-- The Jetty config file to use. -->
 						<jettyXml>${project.build.directory}/bbonfhir-server/bbonfhir-server-app-${bbonfhir-server.version}-jetty-config.xml</jettyXml>
+						
+						<!-- Ensure that the run-forked goal is non-blocking. -->
+						<waitForChild>false</waitForChild>
 
-						<systemProperties>
-							<!-- Set the HTTP(S) ports for Jetty to use. If you modify these, 
-								be sure to also update `FhirTestUtilities.FHIR_API`. -->
-							<systemProperty>
-								<name>jetty.http.port</name>
-								<value>9093</value>
-							</systemProperty>
-							<systemProperty>
-								<name>jetty.ssl.port</name>
-								<value>9094</value>
-							</systemProperty>
-
-							<!-- Configure Jetty's SSL keystores. These were just manually copied 
-								from `bbonfhir-server.git/dev/ssl-stores/`, for convenience. -->
-							<systemProperty>
-								<name>jetty.sslContext.keyStorePath</name>
-								<value>${project.build.directory}/../../dev/ssl-stores/server.keystore</value>
-							</systemProperty>
-							<systemProperty>
-								<name>jetty.sslContext.trustStorePath</name>
-								<value>${project.build.directory}/../../dev/ssl-stores/server.truststore</value>
-							</systemProperty>
-
-							<!-- Configure the DB to be used by the FHIR server. The defaults 
-								(above) are to use a temporary in-mem DB. Can be overridden if needed by 
-								properties specified in devs' settings.xml. -->
-							<systemProperty>
-								<name>bbfhir.db.url</name>
-								<value>${its.bbfhir.db.url}</value>
-							</systemProperty>
-							<systemProperty>
-								<name>bbfhir.db.username</name>
-								<value>${its.bbfhir.db.username}</value>
-							</systemProperty>
-							<systemProperty>
-								<name>bbfhir.db.password</name>
-								<value>${its.bbfhir.db.password}</value>
-							</systemProperty>
-						</systemProperties>
+						<!-- Configure the JVM to: -->
+						<!-- * Set the JVM's max heap size. -->
+						<!-- * Set the HTTP(S) ports for Jetty to use. If you modify these, 
+							be sure to also update `FhirTestUtilities.FHIR_API`. -->
+						<!-- * Configure Jetty's SSL keystores. These were just manually copied 
+							from `bbonfhir-server.git/dev/ssl-stores/`, for convenience. -->
+						<!-- * Specify the WAR to run. -->
+						<!-- * Configure the DB to be used by the FHIR server. The defaults 
+							(above) are to use a temporary in-mem DB. Can be overridden if needed by 
+							properties specified in devs' settings.xml. -->
+						<!-- Notes on how this property is handled: 1) Don't let auto-formatting 
+							of this POm add extra spaces or line breaks: you'll get weird errors if you 
+							do, 2) don't quote any of the values: you'll get weird errors if you do. -->
+						<jvmArgs>${its.bbfhir.server.jvmargs} -Djetty.ssl.port=9094 -Djetty.sslContext.keyStorePath=${project.build.directory}/../../dev/ssl-stores/server.keystore -Djetty.sslContext.trustStorePath=${project.build.directory}/../../dev/ssl-stores/server.truststore -Dbbfhir.war.path=${project.build.directory}/bbonfhir-server/bbonfhir-server-app-${bbonfhir-server.version}.war -Dbbfhir.db.url=${its.bbfhir.db.url} -Dbbfhir.db.username=${its.bbfhir.db.username} -Dbbfhir.db.password=${its.bbfhir.db.password}</jvmArgs>
 
 						<!-- Used by the 'stop' goal. -->
 						<stopPort>9966</stopPort>


### PR DESCRIPTION
This PR is designed to resolve [CBBD-125: Tests failing in second FHIR server execution](http://issues.hhsdevcloud.us/browse/CBBD-125), wherein the second module to run Jetty fails because Jetty had never stopped correctly after the first run.