### PR TITLE
CBBD-152:CI builds of data-pipeline failing after switch to HAPI v2.0: OutOfMemoryError: GC overhead limit exceeded

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,6 @@ node {
 				managedFiles: [[fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig:cms-bluebutton-settings-xml', 
 				variable: 'SETTINGS_PATH']]
 		]) {
-		
 			/*
 			 * Pull the AWS credentials from Jenkins credentials store into the build environment. Some of the ITs need 
 			 * these. For example, DataSetMonitorIT uses them to create and teardown S3 buckets in tests.
@@ -40,10 +39,10 @@ node {
 					accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
 				
 				// Run the build.
-				mvn "--settings ${env.SETTINGS_PATH} -Dmaven.test.failure.ignore -Prun-its-with-derby-db -U clean deploy scm:tag"
+				mvn "--settings ${env.SETTINGS_PATH} -Dmaven.test.failure.ignore -Prun-its-with-db-on-disk -U clean deploy scm:tag"
 				
 			}
-		}		
+		}
 	
 	stage 'Archive'
 		step([$class: 'ArtifactArchiver', artifacts: '**/target/*.jar', fingerprint: true, allowEmptyArchive: true])

--- a/bluebutton-data-pipeline-fhir-load/pom.xml
+++ b/bluebutton-data-pipeline-fhir-load/pom.xml
@@ -206,26 +206,4 @@
 		</plugins>
 	</build>
 
-	<profiles>
-		<profile>
-			<!-- When activated via '-Prun-its-with-derby-db' this profile sets the 
-				ITs to run with an on-disk DB, instead of an in-memory one. This needs to 
-				be activated when running on systems without a lot of memory (such as the 
-				CI server). Note that, on Karl's personal laptop, this adds an extra 30 minutes 
-				or so to the project's build time. -->
-			<!-- Note: As of 2016-07-23, the CI server for this project only has 4 
-				GB of memory, and no swap space. Running FhirLoaderIT.loadRifDataSampleB() 
-				takes at least 2.5 GB of free memory, and Cargo was failing on the CI server 
-				due to its inability to reserve that much (when the DB was configured to 
-				be in-memory). -->
-			<id>run-its-with-derby-db</id>
-			<properties>
-				<its.bbfhir.server.jvmargs>-Xmx512m</its.bbfhir.server.jvmargs>
-				<its.bbfhir.db.url>jdbc:hsqldb:file:test</its.bbfhir.db.url>
-				<its.bbfhir.db.username></its.bbfhir.db.username>
-				<its.bbfhir.db.password></its.bbfhir.db.password>
-			</properties>
-		</profile>
-	</profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,26 @@
 				</pluginManagement>
 			</build>
 		</profile>
+
+		<profile>
+			<!-- When activated via '-Prun-its-with-db-on-disk' this profile sets 
+				the ITs to run with an on-disk DB, instead of an in-memory one. This needs 
+				to be activated when running on systems without a lot of memory (such as 
+				the CI server). Note that, on Karl's personal laptop, this adds an extra 
+				40 minutes or so to the project's build time. -->
+			<!-- Note: As of 2016-07-23, the CI server for this project only has 4 
+				GB of memory, and no swap space. Running FhirLoaderIT.loadRifDataSampleB() 
+				takes at least 2.5 GB of free memory (when the DB was configured to be in-memory), 
+				and Cargo was failing on the CI server due to its inability to reserve that 
+				much. -->
+			<id>run-its-with-db-on-disk</id>
+			<properties>
+				<its.bbfhir.server.jvmargs>-Xmx1g</its.bbfhir.server.jvmargs>
+				<its.bbfhir.db.url>jdbc:hsqldb:file:test</its.bbfhir.db.url>
+				<its.bbfhir.db.username></its.bbfhir.db.username>
+				<its.bbfhir.db.password></its.bbfhir.db.password>
+			</properties>
+		</profile>
 	</profiles>
 
 </project>


### PR DESCRIPTION
http://issues.hhsdevcloud.us/browse/CBBD-152

Two things happening here:

1. The amount of RAM assigned to the Wildfly instance has been bumped
from 512m to 1g, as the 512m was causing OoutOfMmemoryErrors now that
we've moved to HAPI 2.0.
2. The Maven profile that customizes the DB used in the ITs has been
moved from the fhir-load POM to the parent POM, so it now affects all
modules. This wasn't needed for anything, but does make things more
consistent.

CBBD-152